### PR TITLE
Adds Doppler Phase Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Retrieves the Steam CDN URLs for CS:GO Item Images from their `market_hash_name`
 Can retrieve CDN images for:
 * Stickers
 * Graffiti (without tint)
-* Weapons
+* Weapons (and doppler phases)
 * Music Kits
 * Tools (Crate Keys, Cases, Stattrak Swap Tool, etc...)
 * Status Icons (Pins, ESports Trophies, Map Contribution Tokens, Service Medals, etc...)
@@ -71,6 +71,7 @@ const cdn = new csgoCDN(user, {logLevel: 'debug'});
 
 cdn.on('ready', () => {
    console.log(cdn.getItemNameURL('M4A4 | 龍王 (Dragon King) (Field-Tested)'));
+   console.log(cdn.getItemNameURL('★ Karambit | Gamma Doppler (Factory New)', cdn.phase.emerald));
 });
 ```
 
@@ -94,9 +95,10 @@ cdn.on('ready', () => {
     }
     ```
     
-### getItemNameURL(marketHashName)
+### getItemNameURL(marketHashName, phase)
 
 * `marketHashName` - The market hash name of an item (ex. "Sticker | Robo" or "AWP | Redline (Field-Tested)")
+* `phase` - Optional weapon phase for doppler skins from the `phase` enum property
 
 **Note: If the item is a weapon, it MUST have an associated wear**
 
@@ -129,6 +131,18 @@ for O(1) retrieval.
 ### itemsGameCDN
 
 Parsed items_game_cdn.txt file as a dictionary
+
+### phase
+
+Doppler phase enum used to specify the phase of a knife
+
+```javascript
+cdn.getItemNameURL('★ Karambit | Gamma Doppler (Factory New)', cdn.phase.emerald);
+cdn.getItemNameURL('★ Huntsman Knife | Doppler (Factory New)', cdn.phase.blackpearl);
+cdn.getItemNameURL('★ Huntsman Knife | Doppler (Factory New)', cdn.phase.phase1);
+cdn.getItemNameURL('★ Flip Knife | Doppler (Minimal Wear)', cdn.phase.ruby);
+cdn.getItemNameURL('★ Flip Knife | Doppler (Minimal Wear)', cdn.phase.sapphire);
+```
 
 ## Events
 

--- a/example.js
+++ b/example.js
@@ -9,21 +9,26 @@ const cred = {
 };
 
 const user = new SteamUser({enablePicsCache: true});
-const csgo = new csgoCDN(user, {musicKits: true, cases: true, tools: true, statusIcons: true, logLevel: 'debug'});
+const cdn = new csgoCDN(user, {musicKits: true, cases: true, tools: true, statusIcons: true, logLevel: 'debug'});
 
-csgo.on('ready', () => {
-    console.log(csgo.getStickerURL('cologne2016/astr_gold', false));
-    console.log(csgo.getStickerURL('cologne2016/astr_gold', true));
-    console.log(csgo.getItemNameURL('M4A4 | 龍王 (Dragon King) (Field-Tested)'));
-    console.log(csgo.getItemNameURL('AWP | Redline (Field-Tested)'));
-    console.log(csgo.getItemNameURL('Sticker | Robo'));
-    console.log(csgo.getItemNameURL('Chroma 3 Case Key'));
-    console.log(csgo.getItemNameURL('Operation Phoenix Weapon Case'));
-    console.log(csgo.getItemNameURL('Operation Phoenix Pass'));
-    console.log(csgo.getItemNameURL('Music Kit | Kelly Bailey, Hazardous Environments'));
-    console.log(csgo.getItemNameURL('StatTrak™ AWP | Redline (Field-Tested)'));
-    console.log(csgo.getItemNameURL('StatTrak™ Music Kit | Noisia, Sharpened'));
-    console.log(csgo.getItemNameURL('Sealed Graffiti | X-Axes (Tracer Yellow)'));
+cdn.on('ready', () => {
+    console.log(cdn.getStickerURL('cologne2016/astr_gold', false));
+    console.log(cdn.getStickerURL('cologne2016/astr_gold', true));
+    console.log(cdn.getItemNameURL('M4A4 | 龍王 (Dragon King) (Field-Tested)'));
+    console.log(cdn.getItemNameURL('AWP | Redline (Field-Tested)'));
+    console.log(cdn.getItemNameURL('Sticker | Robo'));
+    console.log(cdn.getItemNameURL('Chroma 3 Case Key'));
+    console.log(cdn.getItemNameURL('Operation Phoenix Weapon Case'));
+    console.log(cdn.getItemNameURL('Operation Phoenix Pass'));
+    console.log(cdn.getItemNameURL('Music Kit | Kelly Bailey, Hazardous Environments'));
+    console.log(cdn.getItemNameURL('StatTrak™ AWP | Redline (Field-Tested)'));
+    console.log(cdn.getItemNameURL('StatTrak™ Music Kit | Noisia, Sharpened'));
+    console.log(cdn.getItemNameURL('Sealed Graffiti | X-Axes (Tracer Yellow)'));
+    console.log(cdn.getItemNameURL('★ Karambit | Gamma Doppler (Factory New)', cdn.phase.phase1));
+    console.log(cdn.getItemNameURL('★ Karambit | Gamma Doppler (Factory New)', cdn.phase.emerald));
+    console.log(cdn.getItemNameURL('★ Flip Knife | Doppler (Minimal Wear)', cdn.phase.ruby));
+    console.log(cdn.getItemNameURL('★ Flip Knife | Doppler (Minimal Wear)', cdn.phase.sapphire));
+    console.log(cdn.getItemNameURL('★ Huntsman Knife | Doppler (Factory New)', cdn.phase.blackpearl));
 });
 
 SteamTotp.getAuthCode(cred.shared_secret, (err, code) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "csgo-cdn",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Retrieves the Steam CDN URLs for CS:GO Item Images",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
Closes #1 

Allows specifying the doppler phase in `getItemNameURL(marketHashName, phase)`

Examples:
```javascript
cdn.getItemNameURL('★ Karambit | Gamma Doppler (Factory New)', cdn.phase.emerald);
cdn.getItemNameURL('★ Huntsman Knife | Doppler (Factory New)', cdn.phase.blackpearl);
cdn.getItemNameURL('★ Huntsman Knife | Doppler (Factory New)', cdn.phase.phase1);
cdn.getItemNameURL('★ Flip Knife | Doppler (Minimal Wear)', cdn.phase.ruby);
cdn.getItemNameURL('★ Flip Knife | Doppler (Minimal Wear)', cdn.phase.sapphire);
```