### PR TITLE
Fixes Description Tag Case Sensitivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ files which include the sticker, music kit, tools, and status icon images.
 The root of a VDF contains a `dir` file (`pak01_dir.vpk`) that specifies where files are located over multiple packages. If you look in
 the install directory of CS:GO, you'll see `pak01_003.vpk`, `pak01_004.vpk`, etc... where these files are located.
 
-Thankfully, Valve was kind enough (as of writing this) to include all of the relevant images in packages 57, 83, and 84 
-which is only ~400MB.
+Thankfully, Valve was kind enough (as of writing this) to include all of the relevant images in a few packages
+which are only ~400MB.
 
 This library, using node-steam-user, checks the manifest for any updates to the public branch of CS:GO, and if so,
 downloads only the required VPK packages that contain all relevant images if they have changed from the

--- a/example.js
+++ b/example.js
@@ -16,6 +16,7 @@ cdn.on('ready', () => {
     console.log(cdn.getStickerURL('cologne2016/astr_gold', true));
     console.log(cdn.getItemNameURL('M4A4 | 龍王 (Dragon King) (Field-Tested)'));
     console.log(cdn.getItemNameURL('AWP | Redline (Field-Tested)'));
+    console.log(cdn.getItemNameURL('MP7 | Army Recon (Minimal Wear)'));
     console.log(cdn.getItemNameURL('Sticker | Robo'));
     console.log(cdn.getItemNameURL('Chroma 3 Case Key'));
     console.log(cdn.getItemNameURL('Operation Phoenix Weapon Case'));

--- a/index.js
+++ b/index.js
@@ -208,6 +208,15 @@ class CSGOCdn extends EventEmitter {
 
         this.weaponNameMap = Object.keys(this.csgoEnglish).filter(n => n.startsWith("SFUI_WPNHUD"));
 
+        // Ensure paint kit descriptions are lowercase to resolve inconsistencies in the language and items_game file
+        Object.keys(this.itemsGame.paint_kits).forEach((n) => {
+            const kit = this.itemsGame.paint_kits[n];
+
+            if ('description_tag' in kit) {
+                kit.description_tag = kit.description_tag.toLowerCase();
+            }
+        });
+
         this.invertDictionary(this.csgoEnglish);
     }
 
@@ -544,7 +553,7 @@ class CSGOCdn extends EventEmitter {
         const skinName = match[2];
 
         const weaponTag = `#${this.weaponNameMap.find((n) => this.csgoEnglish[n] === weaponName)}`;
-        const skinTag = `#${this.csgoEnglish[skinName]}`;
+        const skinTag = `#${this.csgoEnglish[skinName].toLowerCase()}`;
 
         const paintKits = this.itemsGame.paint_kits;
 


### PR DESCRIPTION
Some paint kits of a description tag with the wrong case capitalization
compared to the other (`#PaintKit_sp_spray_army_Tag` vs
`#Paintkit_sp_spray_army_Tag`).

This PR ensures the description tag is always lowercase.

Closes #3 