### PR TITLE
Fixes Duplicate Language File Matches for Skin Name

### DIFF
--- a/example.js
+++ b/example.js
@@ -30,6 +30,7 @@ cdn.on('ready', () => {
     console.log(cdn.getItemNameURL('★ Flip Knife | Doppler (Minimal Wear)', cdn.phase.ruby));
     console.log(cdn.getItemNameURL('★ Flip Knife | Doppler (Minimal Wear)', cdn.phase.sapphire));
     console.log(cdn.getItemNameURL('★ Huntsman Knife | Doppler (Factory New)', cdn.phase.blackpearl));
+    console.log(cdn.getItemNameURL('AK-47 | Black Laminate (Field-Tested)'));
 });
 
 SteamTotp.getAuthCode(cred.shared_secret, (err, code) => {


### PR DESCRIPTION
For weapons, there are collisions in the skin names. For example, the "Black Laminate" skin has the two corresponding English tags `PaintKit_hy_ak47lam_bw_Tag` and `Paintkit_cu_stonewash_Tag`.

This PR iterates through all the possible tag matches to find the corresponding path in `items_game_cdn`.