### PR TITLE
Fixes Item Name Simplification and Trimming

### DIFF
--- a/example.js
+++ b/example.js
@@ -31,6 +31,7 @@ cdn.on('ready', () => {
     console.log(cdn.getItemNameURL('★ Flip Knife | Doppler (Minimal Wear)', cdn.phase.sapphire));
     console.log(cdn.getItemNameURL('★ Huntsman Knife | Doppler (Factory New)', cdn.phase.blackpearl));
     console.log(cdn.getItemNameURL('AK-47 | Black Laminate (Field-Tested)'));
+    console.log(cdn.getItemNameURL('Boston 2018 Inferno Souvenir Package'));
 });
 
 SteamTotp.getAuthCode(cred.shared_secret, (err, code) => {

--- a/index.js
+++ b/index.js
@@ -574,8 +574,6 @@ class CSGOCdn extends EventEmitter {
 
             const paintKit = paintKits[paintindex].name;
 
-            console.log(paintKit);
-
             const prefabs = this.itemsGame.prefabs;
             const prefab = Object.keys(prefabs).find((n) => {
                 const fab = prefabs[n];
@@ -646,7 +644,15 @@ class CSGOCdn extends EventEmitter {
      * @param {string?} phase Optional Doppler Phase from the phase enum
      */
     getItemNameURL(marketHashName, phase) {
-        marketHashName = marketHashName.trim().replace('StatTrak™ ', '').replace('Souvenir ', '').replace('★ ', '');
+        marketHashName = marketHashName.trim();
+
+        const extraTags = ['★ ', 'StatTrak™ ', 'Souvenir '];
+
+        for (const tag of extraTags) {
+            if (marketHashName.startsWith(tag)) {
+                marketHashName = marketHashName.replace(tag, '');
+            }
+        }
 
         if (this.isWeapon(marketHashName)) {
             return this.getWeaponNameURL(marketHashName, phase);


### PR DESCRIPTION
Ensures that the replacement properties are always at the beginning of
the item name and in the proper order.

Fixes issues with items that end with "Souvenir Package" that are vital
to the item name to find the lookup.