### PR TITLE
Fixes Sticker Material VPK Path Name

### DIFF
--- a/index.js
+++ b/index.js
@@ -509,7 +509,7 @@ class CSGOCdn extends EventEmitter {
             return k.item_name === stickerTag;
         });
 
-        return this.getStickerURL(stickerKits[kitIndex].name, true);
+        return this.getStickerURL(stickerKits[kitIndex].sticker_material, true);
     }
 
     /**


### PR DESCRIPTION
Incorrectly used the `name` property rather than `sticker_material` for
the sticker VPK path.