### PR TITLE
Fixes Numerous market_hash_name Matching Issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules/
 data/
 example.test.js
+testList.js

--- a/example.js
+++ b/example.js
@@ -32,6 +32,7 @@ cdn.on('ready', () => {
     console.log(cdn.getItemNameURL('★ Huntsman Knife | Doppler (Factory New)', cdn.phase.blackpearl));
     console.log(cdn.getItemNameURL('AK-47 | Black Laminate (Field-Tested)'));
     console.log(cdn.getItemNameURL('Boston 2018 Inferno Souvenir Package'));
+    console.log(cdn.getItemNameURL('CS:GO Case Key'));
 });
 
 SteamTotp.getAuthCode(cred.shared_secret, (err, code) => {

--- a/example.js
+++ b/example.js
@@ -33,6 +33,8 @@ cdn.on('ready', () => {
     console.log(cdn.getItemNameURL('AK-47 | Black Laminate (Field-Tested)'));
     console.log(cdn.getItemNameURL('Boston 2018 Inferno Souvenir Package'));
     console.log(cdn.getItemNameURL('CS:GO Case Key'));
+    console.log(cdn.getItemNameURL('★ Karambit'));
+    console.log(cdn.getItemNameURL('AK-47'));
 });
 
 SteamTotp.getAuthCode(cred.shared_secret, (err, code) => {

--- a/index.js
+++ b/index.js
@@ -729,14 +729,14 @@ class CSGOCdn extends EventEmitter {
         else {
             // Other in items
             for (const t of this.csgoEnglish['inverted'][marketHashName] || []) {
-                const tag = `#${t}`;
+                const tag = `#${t.toLowerCase()}`;
                 const items = this.itemsGame.items;
                 const prefabs = this.itemsGame.prefabs;
 
                 let item = Object.keys(items).find((n) => {
                     const i = items[n];
 
-                    return i.item_name === tag;
+                    return i.item_name && i.item_name.toLowerCase() === tag;
                 });
 
                 let path;
@@ -746,7 +746,7 @@ class CSGOCdn extends EventEmitter {
                     item = Object.keys(prefabs).find((n) => {
                         const i = prefabs[n];
 
-                        return i.item_name === tag;
+                        return i.item_name && i.item_name.toLowerCase() === tag;
                     });
 
                     if (!prefabs[item] || !prefabs[item].image_inventory) continue;

--- a/index.js
+++ b/index.js
@@ -627,7 +627,9 @@ class CSGOCdn extends EventEmitter {
                             return i.item_name === weaponTag;
                         });
 
-                        weaponClass = items[item].name;
+                        if (items[item]) {
+                            weaponClass = items[item].name;
+                        }
                     }
                     else {
                         const item = Object.keys(items).find((n) => {
@@ -636,7 +638,9 @@ class CSGOCdn extends EventEmitter {
                             return i.prefab === prefab;
                         });
 
-                        weaponClass = items[item].name;
+                        if (items[item]) {
+                            weaponClass = items[item].name;
+                        }
                     }
 
                     const path = (paintKit ? `${weaponClass}_${paintKit}` : weaponClass).toLowerCase();

--- a/index.js
+++ b/index.js
@@ -703,23 +703,25 @@ class CSGOCdn extends EventEmitter {
      */
     getItemNameURL(marketHashName, phase) {
         marketHashName = marketHashName.trim();
+        let strippedMarketHashName = marketHashName;
 
+        // Weapons and Music Kits can have extra tags we need to ignore
         const extraTags = ['★ ', 'StatTrak™ ', 'Souvenir '];
 
         for (const tag of extraTags) {
-            if (marketHashName.startsWith(tag)) {
-                marketHashName = marketHashName.replace(tag, '');
+            if (strippedMarketHashName.startsWith(tag)) {
+                strippedMarketHashName = strippedMarketHashName.replace(tag, '');
             }
         }
 
-        if (this.isWeapon(marketHashName)) {
-            return this.getWeaponNameURL(marketHashName, phase);
+        if (this.isWeapon(strippedMarketHashName)) {
+            return this.getWeaponNameURL(strippedMarketHashName, phase);
+        }
+        else if (strippedMarketHashName.startsWith('Music Kit |')) {
+            return this.getMusicKitNameURL(strippedMarketHashName);
         }
         else if (marketHashName.startsWith('Sticker |')) {
             return this.getStickerNameURL(marketHashName);
-        }
-        else if (marketHashName.startsWith('Music Kit |')) {
-            return this.getMusicKitNameURL(marketHashName);
         }
         else if (marketHashName.startsWith('Sealed Graffiti |')) {
             return this.getGraffitiNameURL(marketHashName);

--- a/index.js
+++ b/index.js
@@ -617,10 +617,10 @@ class CSGOCdn extends EventEmitter {
 
                     let weaponClass;
 
+                    const items = this.itemsGame.items;
+
                     if (!prefab) {
                         // special knives aren't in the prefab (karambits, etc...)
-                        const items = this.itemsGame.items;
-
                         const item = Object.keys(items).find((n) => {
                             const i = items[n];
 
@@ -630,7 +630,13 @@ class CSGOCdn extends EventEmitter {
                         weaponClass = items[item].name;
                     }
                     else {
-                        weaponClass = prefabs[prefab].item_class;
+                        const item = Object.keys(items).find((n) => {
+                            const i = items[n];
+
+                            return i.prefab === prefab;
+                        });
+
+                        weaponClass = items[item].name;
                     }
 
                     const path = paintKit ? `${weaponClass}_${paintKit}` : weaponClass;

--- a/index.js
+++ b/index.js
@@ -639,7 +639,7 @@ class CSGOCdn extends EventEmitter {
                         weaponClass = items[item].name;
                     }
 
-                    const path = paintKit ? `${weaponClass}_${paintKit}` : weaponClass;
+                    const path = (paintKit ? `${weaponClass}_${paintKit}` : weaponClass).toLowerCase();
 
                     if (this.itemsGameCDN[path]) {
                         return this.itemsGameCDN[path];

--- a/index.js
+++ b/index.js
@@ -731,18 +731,31 @@ class CSGOCdn extends EventEmitter {
             for (const t of this.csgoEnglish['inverted'][marketHashName] || []) {
                 const tag = `#${t}`;
                 const items = this.itemsGame.items;
+                const prefabs = this.itemsGame.prefabs;
 
-                const item = Object.keys(items).find((n) => {
+                let item = Object.keys(items).find((n) => {
                     const i = items[n];
 
                     return i.item_name === tag;
                 });
 
-                if (!items[item] || !items[item].image_inventory) {
-                    continue;
-                }
+                let path;
 
-                const path = `resource/flash/${items[item].image_inventory}.png`;
+                if (!items[item] || !items[item].image_inventory) {
+                    // search the prefabs (ex. CS:GO Case Key)
+                    item = Object.keys(prefabs).find((n) => {
+                        const i = prefabs[n];
+
+                        return i.item_name === tag;
+                    });
+
+                    if (!prefabs[item] || !prefabs[item].image_inventory) continue;
+
+                    path = `resource/flash/${prefabs[item].image_inventory}.png`;
+                }
+                else {
+                    path = `resource/flash/${items[item].image_inventory}.png`;
+                }
 
                 const url = this.getPathURL(path);
 

--- a/index.js
+++ b/index.js
@@ -18,8 +18,6 @@ const defaultConfig = {
     logLevel: 'info'
 };
 
-const wears = ['Factory New', 'Minimal Wear', 'Field-Tested', 'Well-Worn', 'Battle-Scarred'];
-
 const neededDirectories = {
     stickers: 'resource/flash/econ/stickers',
     graffiti: 'resource/flash/econ/stickers/default',
@@ -490,8 +488,48 @@ class CSGOCdn extends EventEmitter {
      * @return {boolean} Whether a weapon
      */
     isWeapon(marketHashName) {
-        for (const wear of wears) {
-            if (marketHashName.includes(wear)) return true;
+        const prefabs = this.itemsGame.prefabs;
+        const items = this.itemsGame.items;
+        const weaponName = marketHashName.split('|')[0].trim();
+
+        const weaponTags = this.csgoEnglish['inverted'][weaponName];
+
+        if (!weaponTags) return false;
+
+        // For every matching weapon tag...
+        for (const t of weaponTags) {
+            const weaponTag = `#${t}`;
+
+            const prefab = Object.keys(prefabs).find((n) => {
+                const fab = prefabs[n];
+
+                return fab.item_name === weaponTag;
+            });
+
+            let fab;
+
+            if (!prefab) {
+                // special knives aren't in the prefab (karambits, etc...)
+                const item = Object.keys(items).find((n) => {
+                    const i = items[n];
+
+                    return i.item_name === weaponTag;
+                });
+
+                fab = items[item];
+            }
+            else {
+                fab = prefabs[prefab];
+            }
+
+            if (fab && fab.used_by_classes) {
+                const used = fab.used_by_classes;
+
+                // Ensure that the item is used by one of the sides
+                if (used['terrorists'] || used['counter-terrorists']) {
+                    return true;
+                }
+            }
         }
 
         return false;


### PR DESCRIPTION
This PR is related entirely to the code paths for converting `market_hash_name` to the image URL.

Fixes:
- Conflicting case sensitive weapon language references
- Item name simplification/extraction and trimming
- Duplicate match handling for skin names, weapon names, paint indexes
- Ensures weapon tags are lowercase
- Improves Robustness of weapon checking from `market_hash_name` by attempting to find the weapon instead of checking for wear
- Searches prefabs in the case of no match for "other" items
- Vanilla item support

Thanks to #5 for the list of missing items.