### PR TITLE
Adds Support for No Wear for a Weapon in it's market_hash_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ cdn.on('ready', () => {
 * `marketHashName` - The market hash name of an item (ex. "Sticker | Robo" or "AWP | Redline (Field-Tested)")
 * `phase` - Optional weapon phase for doppler skins from the `phase` enum property
 
-**Note: If the item is a weapon, it MUST have an associated wear**
+**Note: If the item is a weapon, you can omit the wear (ex. `AK-47` or `★ Karambit`)**
 
 Ensure that you have enabled the relevant VPK downloading for the item category by using the options in the constructor.
 

--- a/example.js
+++ b/example.js
@@ -35,6 +35,8 @@ cdn.on('ready', () => {
     console.log(cdn.getItemNameURL('CS:GO Case Key'));
     console.log(cdn.getItemNameURL('★ Karambit'));
     console.log(cdn.getItemNameURL('AK-47'));
+    console.log(cdn.getItemNameURL('★ Karambit | Forest DDPAT'));
+    console.log(cdn.getItemNameURL('AWP | Redline'));
 });
 
 SteamTotp.getAuthCode(cred.shared_secret, (err, code) => {

--- a/index.js
+++ b/index.js
@@ -18,6 +18,8 @@ const defaultConfig = {
     logLevel: 'info'
 };
 
+const wears = ['Factory New', 'Minimal Wear', 'Field-Tested', 'Well-Worn', 'Battle-Scarred'];
+
 const neededDirectories = {
     stickers: 'resource/flash/econ/stickers',
     graffiti: 'resource/flash/econ/stickers/default',
@@ -615,21 +617,19 @@ class CSGOCdn extends EventEmitter {
      * @return {string|void} Weapon image URL
      */
     getWeaponNameURL(marketHashName, phase) {
-        let match;
+        const hasWear = wears.findIndex((n) => marketHashName.includes(n)) > -1;
 
-        // Account for vanilla items
-        if (marketHashName.includes('|')) {
-            const reg = /(.*) \| (.*) \(.*\)/;
-            match = marketHashName.match(reg);
-        }
-        else {
-            match = [marketHashName, marketHashName];
+        if (hasWear) {
+            // remove it
+            marketHashName = marketHashName.replace(/\([^)]*\)$/, '');
         }
 
-        if (!match) return;
+        const match = marketHashName.split('|').map((m) => m.trim());
 
-        const weaponName = match[1];
-        const skinName = match[2];
+        const weaponName = match[0];
+        const skinName = match[1];
+
+        if (!weaponName) return;
 
         const weaponTags = this.csgoEnglish['inverted'][weaponName] || [];
         const prefabs = this.itemsGame.prefabs;


### PR DESCRIPTION
Allows calls such as `cdn.getItemNameURL('AWP | Redline')`