### PR TITLE
Fix the bug that crashed the script with an omninous error message.

### DIFF
--- a/example.js
+++ b/example.js
@@ -48,8 +48,7 @@ SteamTotp.getAuthCode(cred.shared_secret, (err, code) => {
         accountName: cred.username,
         password: cred.password,
         rememberPassword: true,
-        twoFactorCode: code,
-        logonID: 2121,
+        twoFactorCode: code
     };
 
     console.log('Logging into Steam....');


### PR DESCRIPTION
After I forked the project for another CDN, I noticed that the whole thing crashed because of the logonID.