### PR TITLE
Use more precise dir name

### DIFF
--- a/index.js
+++ b/index.js
@@ -184,7 +184,7 @@ class CSGOCdn extends EventEmitter {
         const [manifest] = await this.user.getManifestAsync(730, 731, manifestId);
         const manifestFiles = manifest.files;
 
-        const dirFile = manifest.files.find((file) => file.filename.endsWith("pak01_dir.vpk"));
+        const dirFile = manifest.files.find((file) => file.filename.endsWith("csgo\\pak01_dir.vpk"));
         const itemsGameFile = manifest.files.find((file) => file.filename.endsWith("items_game.txt"));
         const itemsGameCDNFile = manifest.files.find((file) => file.filename.endsWith("items_game_cdn.txt"));
         const csgoEnglishFile = manifest.files.find((file) => file.filename.endsWith("csgo_english.txt"));


### PR DESCRIPTION
It seems like there has been a file with name `platform_pak01_dir.vpk` added by Valve. This resulted in downloading the wrong file from the manifest, also saving it as `platform_pak01_dir.vpk`. Renaming the file manually obviously wont fix it, since it is the wrong file.
This resolves https://github.com/Step7750/node-csgo-cdn/issues/28