### PR TITLE
Fixes error that the Procedure can't find the pak01_dir.vpk

### DIFF
--- a/index.js
+++ b/index.js
@@ -184,7 +184,7 @@ class CSGOCdn extends EventEmitter {
         const [manifest] = await this.user.getManifestAsync(730, 731, manifestId);
         const manifestFiles = manifest.files;
 
-        const dirFile = manifest.files.find((file) => file.filename.endsWith("pak01_dir.vpk"));
+        const dirFile = manifest.files.find((file) => file.filename.endsWith("csgo\\pak01_dir.vpk"));
         const itemsGameFile = manifest.files.find((file) => file.filename.endsWith("items_game.txt"));
         const itemsGameCDNFile = manifest.files.find((file) => file.filename.endsWith("items_game_cdn.txt"));
         const csgoEnglishFile = manifest.files.find((file) => file.filename.endsWith("csgo_english.txt"));


### PR DESCRIPTION
May be a generic fix but it works for me. 
Instead of the correct "pak01_dir.vpk", the Procedure downloads a "platform_pak01_dir.vpk" (at initial download) and tries to open the "pak01_dir.vpk", which leads to the following error, since the pak01_dir dosent exists:

(node:6452) UnhandledPromiseRejectionWarning: Error: ENOENT: no such file or directory, open 'temp/VPKFiles/pak01_dir.vpk'
    at Object.openSync (fs.js:440:3)
    at Object.readFileSync (fs.js:342:35)
    at VPK.load (C:\Users\Luis\Desktop\CSGO_UV_Generator\node_modules\vpk\index.js:132:37)
    at StickerCDN.loadVPK (C:\Users\Luis\Desktop\CSGO_UV_Generator\index.js:395:21)
    at StickerCDN.update (C:\Users\Luis\Desktop\CSGO_UV_Generator\index.js:209:14)
(node:6452) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:6452) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.