### PR TITLE
Fix missing depots object on getProductInfo method

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,7 +141,7 @@ class CSGOCdn extends EventEmitter {
     getProductInfo() {
         this.log.debug('Obtaining CS:GO product info');
         return new Promise((resolve, reject) => {
-            this.user.getProductInfo([730], [], (apps, packages, unknownApps, unknownPackages) => {
+            this.user.getProductInfo([730], [], true, (apps, packages, unknownApps, unknownPackages) => {
                 resolve([apps, packages, unknownApps, unknownPackages]);
             });
         });
@@ -299,7 +299,7 @@ class CSGOCdn extends EventEmitter {
      * Loads the CSGO dir VPK specified in the config
      */
     loadVPK() {
-        this.vpkDir = new vpk(this.config.directory + '/pak01_dir.vpk');
+        this.vpkDir = new vpk(this.config.directory + '/platform_pak01_dir.vpk');
         this.vpkDir.load();
 
         this.vpkFiles = this.vpkDir.files.filter((f) => f.startsWith('resource/flash/econ/stickers'));

--- a/index.js
+++ b/index.js
@@ -299,7 +299,7 @@ class CSGOCdn extends EventEmitter {
      * Loads the CSGO dir VPK specified in the config
      */
     loadVPK() {
-        this.vpkDir = new vpk(this.config.directory + '/platform_pak01_dir.vpk');
+        this.vpkDir = new vpk(this.config.directory + '/pak01_dir.vpk');
         this.vpkDir.load();
 
         this.vpkFiles = this.vpkDir.files.filter((f) => f.startsWith('resource/flash/econ/stickers'));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,21 @@
 {
   "name": "csgo-cdn",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bbob/parser": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@bbob/parser/-/parser-2.5.3.tgz",
-      "integrity": "sha512-8oehN7qfJnEYu1fu1WnEQ95dluoeAQjGTHiMfVb+rW7Iu0jKy+4qcI9Xie4A7j6ro9VtEY/7j44mG4iw6KPXqw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@bbob/parser/-/parser-2.6.2.tgz",
+      "integrity": "sha512-o3ZlvDlBaT8DmH1Un3+jdLNidMzkpB8s+dRyOO/1t7ahzk1svxhCDM15hNVGTy0zKOfBr1nQdwXd5ZuSG1nbAA==",
       "requires": {
-        "@bbob/plugin-helper": "^2.5.3"
+        "@bbob/plugin-helper": "^2.6.2"
       }
     },
     "@bbob/plugin-helper": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@bbob/plugin-helper/-/plugin-helper-2.5.3.tgz",
-      "integrity": "sha512-b0oYcxmX7ioLtSJ2kKDhqSmaOyktmTcIUNmCMYb+0IAE3Pl2tPXF3MrESBRg8eW9MfBL/gSm6f0m0HJdPiFPBg=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@bbob/plugin-helper/-/plugin-helper-2.6.2.tgz",
+      "integrity": "sha512-PUdwOQaLxKfyYTCg9As6RU544slQRGF5f71mTq+Dg4d1fNsi5ACv20W5A19tVxPVpJd8U+BbMrVNTxJIOEqT2Q=="
     },
     "@doctormckay/stats-reporter": {
       "version": "1.0.4",
@@ -23,9 +23,9 @@
       "integrity": "sha1-2qHkLw5yjG+1ufueFI8WEGd8d0A="
     },
     "@doctormckay/stdlib": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@doctormckay/stdlib/-/stdlib-1.10.2.tgz",
-      "integrity": "sha512-lBW0upY7Cgk+zbjDMH4q4tuvQ0ss+/jd2KMLHqboGw4p0Mc3RUJGhCkMS1c+eUNd6KbNE//F0DYJzNTYq5kjqg=="
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@doctormckay/stdlib/-/stdlib-1.11.2.tgz",
+      "integrity": "sha512-iuCNW9VVtu/hwfPMMiXAJXQfFMqW9SIkMYDQASnvY3JTP02RL0yhZE3IfsJKi5A7ht5HglgPKXRaMCYW4wDXVA=="
     },
     "@doctormckay/steam-crypto": {
       "version": "1.2.0",
@@ -87,19 +87,19 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@types/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
+      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
     },
     "@types/node": {
-      "version": "10.14.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.16.tgz",
-      "integrity": "sha512-/opXIbfn0P+VLt+N8DE4l8Mn8rbhiJgabU96ZJ0p9mxOkIks5gh6RUnpHak7Yh0SFkyjO/ODbxsQQPV2bpMmyA=="
+      "version": "13.13.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.39.tgz",
+      "integrity": "sha512-wct+WgRTTkBm2R3vbrFOqyZM5w0g+D8KnhstG9463CJBVC3UVZHMToge7iMBR1vDl/I+NWFHUeK9X+JcF0rWKw=="
     },
     "adm-zip": {
-      "version": "0.4.13",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.13.tgz",
-      "integrity": "sha512-fERNJX8sOXfel6qCBCMPvZLzENBEhZTzKqg6vrOW5pvoEaQuJhRU4ndTAh6lHOxn1I6jnz2NHra56ZODM751uw=="
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.16.tgz",
+      "integrity": "sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg=="
     },
     "ajv": {
       "version": "5.5.2",
@@ -116,6 +116,11 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/appdirectory/-/appdirectory-0.1.0.tgz",
       "integrity": "sha1-62yBYyDnsqsW9e2ZfyjYIF31Y3U="
+    },
+    "array-filter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
+      "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM="
     },
     "asn1": {
       "version": "0.2.4",
@@ -142,6 +147,14 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "available-typed-arrays": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz",
+      "integrity": "sha512-XWX3OX8Onv97LMk/ftVyBibpGwY5a8SmuxZPzeOxqmuEqUCOM9ZE+uIaD1VNJ5QnvU2UQusvmKbuM1FR8QWGfQ==",
+      "requires": {
+        "array-filter": "^1.0.0"
+      }
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -170,7 +183,7 @@
     "binarykvparser": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binarykvparser/-/binarykvparser-2.2.0.tgz",
-      "integrity": "sha1-scKhp9WTXiNSCBzHjmcg7IfLHQU=",
+      "integrity": "sha512-mGBKngQF9ui53THcMjgjd0LrBH/HsI2Vywfjq52udSAmRGG87h0vjhkqun0kF+iC4rQ2jLZqldwJE7YN2ueiWw==",
       "requires": {
         "long": "^3.2.0"
       },
@@ -201,6 +214,15 @@
       "integrity": "sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=",
       "requires": {
         "long": "~3"
+      }
+    },
+    "call-bind": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.1.tgz",
+      "integrity": "sha512-tvAvUwNcRikl3RVF20X9lsYmmepsovzTWeJiXjO0PkJp15uy/6xKFZOQtuiSULwYW+6ToZBprphCgWXC2dSgcQ==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
       }
     },
     "caseless": {
@@ -344,22 +366,28 @@
       "integrity": "sha1-DWKAz1B9hCQr7+NaUSta5L53xU4="
     },
     "es-abstract": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
-      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+      "version": "1.18.0-next.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+      "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
       "requires": {
-        "es-to-primitive": "^1.2.0",
+        "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
-        "is-callable": "^1.1.4",
-        "is-regex": "^1.0.4",
-        "object-keys": "^1.0.12"
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.2.2",
+        "is-negative-zero": "^2.0.0",
+        "is-regex": "^1.1.1",
+        "object-inspect": "^1.8.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.1",
+        "string.prototype.trimend": "^1.0.1",
+        "string.prototype.trimstart": "^1.0.1"
       }
     },
     "es-to-primitive": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
-      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -406,6 +434,11 @@
       "resolved": "https://registry.npmjs.org/file-manager/-/file-manager-2.0.0.tgz",
       "integrity": "sha512-AX9jtqrrHK9JT4v3J7uMZGkDNiuuG4y4T6LoNm3lKzT/vReLCY8mnRWIpaG2ffNEpJHSkiwKejpu8x8THEYPzg=="
     },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -425,6 +458,16 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "get-intrinsic": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.2.tgz",
+      "integrity": "sha512-aeX0vrFm21ILl3+JpFFRNe9aUvp6VFZb2/CTbgLb8j75kOhvoNYjt9d8KA/tJG4gSo8nzEDedRl0h7vDmBYRVg==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
     },
     "getpass": {
       "version": "0.1.7",
@@ -457,9 +500,9 @@
       }
     },
     "has-symbols": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
     },
     "hasha": {
       "version": "3.0.0",
@@ -490,9 +533,12 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "is-arguments": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
-      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.0.tgz",
+      "integrity": "sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==",
+      "requires": {
+        "call-bind": "^1.0.0"
+      }
     },
     "is-arrayish": {
       "version": "0.3.2",
@@ -500,26 +546,31 @@
       "integrity": "sha1-RXSirlb3qyBolvtDHq7tBm/fjwM="
     },
     "is-callable": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+      "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA=="
     },
     "is-date-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
     },
     "is-generator-function": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.7.tgz",
-      "integrity": "sha512-YZc5EwyO4f2kWCax7oegfuSr9mFz1ZvieNYBEjmukLxgXfBUbxAWGVF7GZf0zidYtoBl3WvC07YK0wT76a+Rtw=="
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.8.tgz",
+      "integrity": "sha512-2Omr/twNtufVZFr1GhxjOMFPAj2sjc/dKaIqBhvo4qciXfJmITGH6ZGd8eZYNHza8t1y0e01AuqRhJwfWp26WQ=="
+    },
+    "is-negative-zero": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
     },
     "is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+      "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
       "requires": {
-        "has": "^1.0.1"
+        "has-symbols": "^1.0.1"
       }
     },
     "is-stream": {
@@ -528,11 +579,23 @@
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-symbol": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
-      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
       "requires": {
-        "has-symbols": "^1.0.0"
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "is-typed-array": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.4.tgz",
+      "integrity": "sha512-ILaRgn4zaSrVNXNGtON6iFNotXW3hAPF3+0fB1usg2jFlWqo5fEDdmJkz0zBfoi7Dgskr8Khi2xZ8cXqZEfXNA==",
+      "requires": {
+        "available-typed-arrays": "^1.0.2",
+        "call-bind": "^1.0.0",
+        "es-abstract": "^1.18.0-next.1",
+        "foreach": "^2.0.5",
+        "has-symbols": "^1.0.1"
       }
     },
     "is-typedarray": {
@@ -655,20 +718,25 @@
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU="
     },
+    "object-inspect": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
+    },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
-    "object.entries": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
-      "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+    "object.assign": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
       "requires": {
+        "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.12.0",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3"
+        "has-symbols": "^1.0.1",
+        "object-keys": "^1.1.1"
       }
     },
     "one-time": {
@@ -695,9 +763,9 @@
       "integrity": "sha1-o31zL0JxtKsa0HDTVQjoKQeI/6o="
     },
     "protobufjs": {
-      "version": "6.8.8",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.8.tgz",
-      "integrity": "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==",
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.2.tgz",
+      "integrity": "sha512-27yj+04uF6ya9l+qfpH187aqEzfCF4+Uit0I9ZBQVqK09hk/SQzKa2MUqUpXaVa7LOFRg1TSSr3lVxGOk6c0SQ==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -709,8 +777,8 @@
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.0",
-        "@types/node": "^10.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": "^13.7.0",
         "long": "^4.0.0"
       },
       "dependencies": {
@@ -842,13 +910,12 @@
       }
     },
     "steam-user": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/steam-user/-/steam-user-4.12.3.tgz",
-      "integrity": "sha512-dDP+JtDIWcXWBKxguMr+uBLgpp93EjELtPKOHQRQGXWhKkr2nAXia8TLKTzy2fsolW7AYZaXY3gyygAu9EJLPw==",
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/steam-user/-/steam-user-4.19.2.tgz",
+      "integrity": "sha512-NvGC4ET/wJrRICh2xVqDS2iVCXM2qCpLZC4IufLBGOSgYrqNMCNMv8NvETnjjue4numXIJhsBZ+t8s3tfArgDw==",
       "requires": {
         "@bbob/parser": "^2.2.0",
-        "@doctormckay/stats-reporter": "^1.0.3",
-        "@doctormckay/stdlib": "^1.6.0",
+        "@doctormckay/stdlib": "^1.11.1",
         "@doctormckay/steam-crypto": "^1.2.0",
         "adm-zip": "^0.4.13",
         "appdirectory": "^0.1.0",
@@ -857,11 +924,11 @@
         "file-manager": "^2.0.0",
         "lzma": "^2.3.2",
         "protobufjs": "^6.8.8",
-        "steam-appticket": "^1.0.0",
+        "steam-appticket": "^1.0.1",
         "steam-totp": "^2.0.1",
         "steamid": "^1.1.0",
         "vdf": "^0.0.2",
-        "websocket13": "^2.0.1"
+        "websocket13": "^2.1.3"
       }
     },
     "steamid": {
@@ -870,6 +937,24 @@
       "integrity": "sha512-t86YjtP1LtPt8D+TaIARm6PtC9tBnF1FhxQeLFs6ohG7vDUfQuy/M8II14rx1TTUkVuYoWHP/7DlvTtoCGULcw==",
       "requires": {
         "cuint": "^0.2.1"
+      }
+    },
+    "string.prototype.trimend": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
+      "integrity": "sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz",
+      "integrity": "sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
       }
     },
     "string_decoder": {
@@ -914,15 +999,16 @@
       "optional": true
     },
     "util": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.1.tgz",
-      "integrity": "sha512-MREAtYOp+GTt9/+kwf00IYoHZyjM8VU4aVrkzUlejyqaIjd2GztVl5V9hGXKlvBKE3gENn/FMfHE5v6hElXGcQ==",
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.3.tgz",
+      "integrity": "sha512-I8XkoQwE+fPQEhy9v012V+TSdH2kp9ts29i20TaaDUXsg7x/onePbhFJUExBfv/2ay1ZOp/Vsm3nDlmnFGSAog==",
       "requires": {
         "inherits": "^2.0.3",
         "is-arguments": "^1.0.4",
         "is-generator-function": "^1.0.7",
-        "object.entries": "^1.1.0",
-        "safe-buffer": "^5.1.2"
+        "is-typed-array": "^1.1.3",
+        "safe-buffer": "^5.1.2",
+        "which-typed-array": "^1.1.2"
       }
     },
     "util-deprecate": {
@@ -963,19 +1049,33 @@
       }
     },
     "websocket-extensions": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
-      "integrity": "sha1-XS/yKXcAPsaHpLhwc9+7rBRszyk="
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg=="
     },
     "websocket13": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/websocket13/-/websocket13-2.1.0.tgz",
-      "integrity": "sha512-prE4wrGkzQvapPiHyTvIbPRqFRFCaMDSiAFT79UhH6UaamAcGm7wlVZTRyD/fUKQ2sJkTwiNkL5YtbnDdPFL2w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/websocket13/-/websocket13-2.2.0.tgz",
+      "integrity": "sha512-m3aS0sLEM9dRM2+Cvgakdr/oLqyfAObdUlUqU3gdw3PuI81k1Hw3PWdwJsehvRRlScHolA13yYsx/X3OUzsTLA==",
       "requires": {
         "@doctormckay/stdlib": "^1.8.0",
         "bytebuffer": "^5.0.1",
         "permessage-deflate": "^0.1.6",
         "websocket-extensions": "^0.1.2"
+      }
+    },
+    "which-typed-array": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.4.tgz",
+      "integrity": "sha512-49E0SpUe90cjpoc7BOJwyPHRqSAd12c10Qm2amdEZrJPCY2NDxaW01zHITrem+rnETY3dwrbH3UUrUwagfCYDA==",
+      "requires": {
+        "available-typed-arrays": "^1.0.2",
+        "call-bind": "^1.0.0",
+        "es-abstract": "^1.18.0-next.1",
+        "foreach": "^2.0.5",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.1",
+        "is-typed-array": "^1.1.3"
       }
     },
     "winston": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "hasha": "^3.0.0",
     "simple-vdf": "^1.1.0",
     "steam-totp": "^2.0.1",
-    "steam-user": "^4.12.3",
+    "steam-user": "^4.19.2",
     "vpk": "0.2.0",
     "winston": "^3.0.0-rc1"
   },


### PR DESCRIPTION


- Depots object is only present on `packages['730'].appinfo` – returned from `getProductInfo` – if an access token is passed
- renamed pak01_dir.vpk -> platform_pak01_dir.vpk
- bumped steam-user to 4.19.2 to fix an http issue in downloadFile